### PR TITLE
 Remove unnecessary, overqualified element parts of combination selectors

### DIFF
--- a/darkvector.less
+++ b/darkvector.less
@@ -352,11 +352,11 @@ td.diff-context {
     background: transparent
 }
 
-div#mw-head #right-navigation div.darkvectorMenu h3 {
+#mw-head #right-navigation div.darkvectorMenu h3 {
     background: inherit
 }
 
-div#mw-head div.darkvectorMenu h3 span {
+#mw-head div.darkvectorMenu h3 span {
     color: #e69710
 }
 
@@ -388,13 +388,13 @@ div.darkvectorMenu#p-cactions ul {
     background-color: #4c4c4c
 }
 
-#mw-navigation div#mw-panel div.portal {
+#mw-navigation #mw-panel div.portal {
     background-image: none;
     border-top: 1px solid #4c4c4c
 }
 
-#mw-navigation div#mw-panel div.portal#p-logo,
-#mw-navigation div#mw-panel div.portal#p-navigation {
+#mw-navigation #mw-panel div.portal#p-logo,
+#mw-navigation #mw-panel div.portal#p-navigation {
     border-top: none
 }
 
@@ -518,7 +518,7 @@ pre,
 }
 
 body.darkvector-animateLayout .mw-body,
-body.darkvector-animateLayout div#footer,
+body.darkvector-animateLayout #footer,
 body.darkvector-animateLayout #left-navigation {
     -webkit-transition: margin-left 250ms, padding 250ms;
     -moz-transition: margin-left 250ms, padding 250ms;
@@ -798,7 +798,7 @@ body.rtl div.darkvectorMenu {
     direction: rtl
 }
 
-div#mw-head div.darkvectorMenu h3 {
+#mw-head div.darkvectorMenu h3 {
     float: left;
     background-image: url('images/tab-break.png');
     background-repeat: no-repeat;
@@ -1047,14 +1047,14 @@ div.darkvectorMenu li.selected a:visited {
     height: 5em
 }
 
-div#mw-head {
+#mw-head {
     position: absolute;
     top: 0;
     right: 0;
     width: 100%
 }
 
-div#mw-head h3 {
+#mw-head h3 {
     margin: 0;
     padding: 0
 }
@@ -1089,7 +1089,7 @@ div#mw-head h3 {
     text-decoration: none
 }
 
-div#mw-panel {
+#mw-panel {
     font-size: inherit;
     position: absolute;
     top: 160px;
@@ -1098,7 +1098,7 @@ div#mw-panel {
     left: 0
 }
 
-div#mw-panel div.portal {
+#mw-panel .portal {
     margin: 0 .6em 0 .7em;
     padding: .25em 0;
     direction: ltr;
@@ -1107,7 +1107,7 @@ div#mw-panel div.portal {
     background-image: url('images/portal-break.png')
 }
 
-div#mw-panel div.portal h3 {
+#mw-panel .portal h3 {
     font-size: .75em;
     color: #656565;
     font-weight: normal;
@@ -1117,19 +1117,19 @@ div#mw-panel div.portal h3 {
     border: none
 }
 
-div#mw-panel div.portal div.body {
+#mw-panel .portal .body {
     margin: 0 0 0 1.25em;
     padding-top: 0
 }
 
-div#mw-panel div.portal div.body ul {
+#mw-panel .portal .body ul {
     list-style-type: none;
     list-style-image: none;
     margin: 0;
     padding: 0
 }
 
-div#mw-panel div.portal div.body ul li {
+#mw-panel .portal .body ul li {
     line-height: 1.125em;
     margin: 0;
     padding: .25em 0;
@@ -1137,42 +1137,42 @@ div#mw-panel div.portal div.body ul li {
     word-wrap: break-word
 }
 
-div#mw-panel div.portal div.body ul li a {
+#mw-panel .portal .body ul li a {
     color: #e69710
 }
 
-div#mw-panel div.portal div.body ul li a:visited {
+#mw-panel .portal .body ul li a:visited {
     color: #D28A0D
 }
 
-div#mw-panel div.portal.first {
+#mw-panel .portal.first {
     background-image: none;
     margin-top: 0
 }
 
-div#mw-panel div.portal.first h3 {
+#mw-panel .portal.first h3 {
     display: none
 }
 
-div#mw-panel div.portal.first div.body {
+#mw-panel .portal.first .body {
     margin-left: .5em
 }
 
-div#footer {
+#footer {
     margin-left: 10em;
     margin-top: 0;
     padding: .75em;
     direction: ltr
 }
 
-div#footer ul {
+#footer ul {
     list-style-type: none;
     list-style-image: none;
     margin: 0;
     padding: 0
 }
 
-div#footer ul li {
+#footer ul li {
     margin: 0;
     padding: 0;
     padding-top: .5em;
@@ -1181,27 +1181,27 @@ div#footer ul li {
     font-size: .7em
 }
 
-div#footer #footer-icons {
+#footer #footer-icons {
     float: right
 }
 
-div#footer #footer-icons li {
+#footer #footer-icons li {
     float: left;
     margin-left: .5em;
     line-height: 2em;
     text-align: right
 }
 
-div#footer #footer-info li {
+#footer #footer-info li {
     line-height: 1.4em
 }
 
-div#footer #footer-places li {
+#footer #footer-places li {
     float: left;
     margin-right: 1em;
     line-height: 2em
 }
 
-body.ltr div#footer #footer-places {
+body.ltr #footer #footer-places {
     float: left
 }


### PR DESCRIPTION
Those combinations origin from a time when these were seen as faster
to be rendered (at least dating back to 2011). Not only is this
reason no longer true, it also holds us back to start using semantic
HTML5 sectioning elements like `nav` for `.portal`.
See https://phabricator.wikimedia.org/T248137 for more information.