### PR TITLE
Avoid ignoring the right viewmywatchlist

### DIFF
--- a/DarkVectorTemplate.php
+++ b/DarkVectorTemplate.php
@@ -45,7 +45,7 @@ class DarkVectorTemplate extends BaseTemplate {
 				$isWatched = $user->isWatched( $relevantTitle );
 			} else {
 				$instance = MediaWiki\MediaWikiServices::getInstance();
-				$isWatched = $instance->getWatchedItemStore()->isWatched(
+				$isWatched = $instance->getWatchlistManager()->isWatched(
 					$user,
 					$relevantTitle
 				);


### PR DESCRIPTION
In #25 it was added compatibility to MW 1.38+ for the watchlist, but this bypasses the right 'viewmywatchlist'. Not a big deal probably, but it’s better to take it into account and all other skins* using `isWatched()` use `MediaWikiServices::getInstance()->getWatchlistManager()->isWatched()`.

\* I found it in the skins Apex, Metrolook, Nimbus, Webplatform, Strapping and indirectly the skins using the hook SkinTemplateNavigation (like Vector) because the watch action is only present [if the rights 'viewmywatchlist' and 'editmywatchlist' are active](https://github.com/wikimedia/mediawiki/blob/89dc14bc60c39a101f0c9a235c40dbeb91ea08d8/includes/skins/SkinTemplate.php#L1486-L1509).