### PR TITLE
Replace deprecated Hooks::run()

### DIFF
--- a/DarkVectorTemplate.php
+++ b/DarkVectorTemplate.php
@@ -22,6 +22,8 @@
  * @ingroup Skins
  */
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * QuickTemplate class for DarkVector skin
  * @ingroup Skins
@@ -44,7 +46,7 @@ class DarkVectorTemplate extends BaseTemplate {
 			if ( method_exists( $user, 'isWatched' ) ) {
 				$isWatched = $user->isWatched( $relevantTitle );
 			} else {
-				$instance = MediaWiki\MediaWikiServices::getInstance();
+				$instance = MediaWikiServices::getInstance();
 				$isWatched = $instance->getWatchlistManager()->isWatched(
 					$user,
 					$relevantTitle
@@ -332,7 +334,8 @@ class DarkVectorTemplate extends BaseTemplate {
 							echo $this->makeListItem( $key, $val );
 						}
 						if ( $hook !== null ) {
-							Hooks::run( $hook, array( &$this, true ) );
+							$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+							$hookContainer->run( $hook, [ &$this, true ] );
 						}
 						?>
 					</ul>


### PR DESCRIPTION
Deprecated since MediaWiki 1.35, so compatible with current requirement MediaWiki >= 1.39. This function was removed in MediaWiki 1.42.

PS: the hook [SkinTemplateToolboxEnd](https://www.mediawiki.org/wiki/Manual:Hooks/SkinTemplateToolboxEnd) called by this function has been removed in MediaWiki and some other skins, but I’m not sure about the influence of removing it, so I’m conservative in this change.